### PR TITLE
multiple webhooks, configuration for message sending

### DIFF
--- a/.github/workflows/publish_mr.yml
+++ b/.github/workflows/publish_mr.yml
@@ -1,0 +1,37 @@
+name: Publish Docker image
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: edward3h/mc-webhook
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up JDK 11
+        uses: ayltai/setup-graalvm@v1
+        with:
+          java-version: 11
+          graalvm-version: 21.3.0
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew dockerPush -Pgithub_ref=${GITHUB_SHA}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ java {
 	}
 }
 
-version = "0.2"
+version = "0.3"
 
 repositories {
 	mavenCentral()
@@ -80,8 +80,14 @@ tasks.named("dockerfile") {
 }
 
 tasks.named("dockerBuild") {
-	images = [
-		"ghcr.io/edward3h/mc-webhook:latest",
-		"ghcr.io/edward3h/mc-webhook:${project.version}"
-	]
+	if (project.hasProperty("github_ref")) {
+		images = [
+			"ghcr.io/edward3h/mc-webhook:${project.version}-SNAPSHOT-${project.property("github_ref")}"
+		]
+	} else {
+		images = [
+			"ghcr.io/edward3h/mc-webhook:latest",
+			"ghcr.io/edward3h/mc-webhook:${project.version}"
+		]
+	}
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 	implementation 'jakarta.inject:jakarta.inject-api'
 
 	implementation 'org.apache.logging.log4j:log4j-api:2.17.1'
+	implementation 'org.apache.commons:commons-text:1.9'
 
 	runtimeOnly group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.17.1'
 	runtimeOnly 'org.apache.logging.log4j:log4j-core:2.17.1'

--- a/app/src/main/java/org/ethelred/minecraft/webhook/App.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/App.java
@@ -1,3 +1,4 @@
+/* (C) Edward Harman 2022 */
 package org.ethelred.minecraft.webhook;
 
 import io.micronaut.runtime.Micronaut;

--- a/app/src/main/java/org/ethelred/minecraft/webhook/App.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/App.java
@@ -7,9 +7,13 @@ import jakarta.inject.Singleton;
 public class App {
 
     public static void main(String[] args) {
+        // tell Micronaut to look for config in known paths of the docker image
+        System.setProperty(
+            "micronaut.config.files",
+            "/config.yml" // in root of docker image
+        );
         Micronaut
             .build(args)
-            .eagerInitSingletons(true)
             .mainClass(App.class)
             .defaultEnvironments("dev")
             .start();

--- a/app/src/main/java/org/ethelred/minecraft/webhook/BackCompatUrlSetup.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/BackCompatUrlSetup.java
@@ -1,20 +1,26 @@
+/* (C) Edward Harman 2022 */
 package org.ethelred.minecraft.webhook;
 
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.convert.ConversionService;
 import java.net.URL;
 
+/**
+ * this bean maps the original webhook property into the updated system for backwards compatibility
+ */
 @Context
 @Requires(property = "mc-webhook.webhook-url")
 public class BackCompatUrlSetup extends MinecraftServerEventListener {
 
     public BackCompatUrlSetup(
         BeanContext context,
+        ConversionService<?> conversionService,
         @Property(name = "mc-webhook.webhook-url") URL url
     ) {
-        super(context, getConfiguration(url));
+        super(context, conversionService, getConfiguration(url));
     }
 
     private static SenderConfiguration getConfiguration(URL url) {

--- a/app/src/main/java/org/ethelred/minecraft/webhook/BackCompatUrlSetup.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/BackCompatUrlSetup.java
@@ -1,0 +1,25 @@
+package org.ethelred.minecraft.webhook;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import java.net.URL;
+
+@Context
+@Requires(property = "mc-webhook.webhook-url")
+public class BackCompatUrlSetup extends MinecraftServerEventListener {
+
+    public BackCompatUrlSetup(
+        BeanContext context,
+        @Property(name = "mc-webhook.webhook-url") URL url
+    ) {
+        super(context, getConfiguration(url));
+    }
+
+    private static SenderConfiguration getConfiguration(URL url) {
+        var config = new SenderConfiguration();
+        config.setUrl(url); // defaults are ok for other properties
+        return config;
+    }
+}

--- a/app/src/main/java/org/ethelred/minecraft/webhook/ContainerId.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/ContainerId.java
@@ -1,3 +1,4 @@
+/* (C) Edward Harman 2022 */
 package org.ethelred.minecraft.webhook;
 
 import jakarta.inject.Qualifier;

--- a/app/src/main/java/org/ethelred/minecraft/webhook/DefaultDocker.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/DefaultDocker.java
@@ -1,3 +1,4 @@
+/* (C) Edward Harman 2022 */
 package org.ethelred.minecraft.webhook;
 
 import com.github.dockerjava.api.DockerClient;

--- a/app/src/main/java/org/ethelred/minecraft/webhook/DiscordWebhookSender.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/DiscordWebhookSender.java
@@ -1,3 +1,4 @@
+/* (C) Edward Harman 2022 */
 package org.ethelred.minecraft.webhook;
 
 import io.micronaut.context.annotation.Parameter;
@@ -118,8 +119,7 @@ public class DiscordWebhookSender implements Sender {
             }
         } catch (IOException | InterruptedException e) {
             // can't tell at this point whether the message was sent or not - just give up and log
-            System.err.println("Exception in _sendMessage");
-            e.printStackTrace(System.err);
+            LOGGER.error("Exception in _sendMessage", e);
             delay = DEFAULT_DELAY;
         } finally {
             _scheduleNext(delay);

--- a/app/src/main/java/org/ethelred/minecraft/webhook/DiscordWebhookSender.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/DiscordWebhookSender.java
@@ -1,10 +1,13 @@
 package org.ethelred.minecraft.webhook;
 
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Prototype;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
+import jakarta.inject.Named;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.net.http.*;
 import java.net.http.HttpClient;
 import java.util.Optional;
@@ -16,7 +19,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@Singleton
+@Prototype
+@Named("discord")
 public class DiscordWebhookSender implements Sender {
 
     private static final long DEFAULT_DELAY = 3_000;
@@ -30,9 +34,9 @@ public class DiscordWebhookSender implements Sender {
     private final BlockingQueue<String> waiting;
 
     @Inject
-    public DiscordWebhookSender(Options options) {
+    public DiscordWebhookSender(@Parameter URL webhookUrl) {
         try {
-            this.webhook = options.getWebhookUrl().toURI();
+            this.webhook = webhookUrl.toURI();
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
@@ -41,7 +45,7 @@ public class DiscordWebhookSender implements Sender {
         this.waiting = new ArrayBlockingQueue<>(64);
         _scheduleNext(0L);
         LOGGER.info(
-            "DiscordWebhookSender initalized with URL {}",
+            "DiscordWebhookSender initialized with URL {}",
             this.webhook
         );
     }
@@ -136,7 +140,7 @@ public class DiscordWebhookSender implements Sender {
     }
 
     @Override
-    public void sendMessage(String message) {
+    public void sendMessage(MinecraftServerEvent event, String message) {
         LOGGER.debug("sendMessage({})", message.trim());
         //noinspection ResultOfMethodCallIgnored
         waiting.offer(message.trim());

--- a/app/src/main/java/org/ethelred/minecraft/webhook/JsonSender.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/JsonSender.java
@@ -1,0 +1,38 @@
+/* (C) Edward Harman 2022 */
+package org.ethelred.minecraft.webhook;
+
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import jakarta.inject.Named;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Prototype
+@Named("json")
+public class JsonSender implements Sender {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private final BlockingHttpClient client;
+    private final URI url;
+
+    public JsonSender(HttpClient client, @Parameter URL url)
+        throws URISyntaxException {
+        this.client = client.toBlocking();
+        this.url = url.toURI();
+    }
+
+    @Override
+    public void sendMessage(MinecraftServerEvent event, String message) {
+        LOGGER.debug("Send message {}", event);
+        var request = HttpRequest.POST(url, event);
+        var response = client.exchange(request);
+        LOGGER.debug(response);
+    }
+}

--- a/app/src/main/java/org/ethelred/minecraft/webhook/MinecraftServerEvent.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/MinecraftServerEvent.java
@@ -1,3 +1,4 @@
+/* (C) Edward Harman 2022 */
 package org.ethelred.minecraft.webhook;
 
 import io.micronaut.core.annotation.Introspected;
@@ -10,13 +11,13 @@ public class MinecraftServerEvent {
     public MinecraftServerEvent(
         @NonNull Type type,
         @NonNull String containerId,
-        @NonNull String[] containerNames,
+        @NonNull String containerName,
         @NonNull String worldName,
         @Nullable String playerName
     ) {
         this.type = type;
         this.containerId = containerId;
-        this.containerNames = containerNames;
+        this.containerName = containerName;
         this.worldName = worldName;
         this.playerName = playerName;
     }
@@ -39,8 +40,8 @@ public class MinecraftServerEvent {
     }
 
     @NonNull
-    public String[] getContainerNames() {
-        return containerNames;
+    public String getContainerName() {
+        return containerName;
     }
 
     @NonNull
@@ -60,7 +61,7 @@ public class MinecraftServerEvent {
     private final String containerId;
 
     @NonNull
-    private final String[] containerNames;
+    private final String containerName;
 
     @NonNull
     private final String worldName;

--- a/app/src/main/java/org/ethelred/minecraft/webhook/MinecraftServerEvent.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/MinecraftServerEvent.java
@@ -1,0 +1,70 @@
+package org.ethelred.minecraft.webhook;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+
+@Introspected
+public class MinecraftServerEvent {
+
+    public MinecraftServerEvent(
+        @NonNull Type type,
+        @NonNull String containerId,
+        @NonNull String[] containerNames,
+        @NonNull String worldName,
+        @Nullable String playerName
+    ) {
+        this.type = type;
+        this.containerId = containerId;
+        this.containerNames = containerNames;
+        this.worldName = worldName;
+        this.playerName = playerName;
+    }
+
+    enum Type {
+        PLAYER_CONNECTED,
+        PLAYER_DISCONNECTED,
+        SERVER_STARTED,
+        SERVER_STOPPED,
+    }
+
+    @NonNull
+    public Type getType() {
+        return type;
+    }
+
+    @NonNull
+    public String getContainerId() {
+        return containerId;
+    }
+
+    @NonNull
+    public String[] getContainerNames() {
+        return containerNames;
+    }
+
+    @NonNull
+    public String getWorldName() {
+        return worldName;
+    }
+
+    @Nullable
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    @NonNull
+    private final Type type;
+
+    @NonNull
+    private final String containerId;
+
+    @NonNull
+    private final String[] containerNames;
+
+    @NonNull
+    private final String worldName;
+
+    @Nullable
+    private final String playerName;
+}

--- a/app/src/main/java/org/ethelred/minecraft/webhook/MinecraftServerEventListener.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/MinecraftServerEventListener.java
@@ -1,0 +1,57 @@
+package org.ethelred.minecraft.webhook;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.scheduling.annotation.Async;
+import jakarta.inject.Singleton;
+import org.apache.commons.text.StringSubstitutor;
+import org.apache.commons.text.lookup.StringLookup;
+
+@Singleton
+@EachBean(SenderConfiguration.class)
+public class MinecraftServerEventListener
+    implements ApplicationEventListener<MinecraftServerEvent> {
+
+    private static final BeanIntrospection<MinecraftServerEvent> eventIntrospection = BeanIntrospection.getIntrospection(
+        MinecraftServerEvent.class
+    );
+    private final SenderConfiguration configuration;
+    private final Sender sender;
+
+    public MinecraftServerEventListener(
+        BeanContext beanContext,
+        SenderConfiguration configuration
+    ) {
+        this.configuration = configuration;
+        this.sender =
+            beanContext.createBean(
+                Sender.class,
+                Qualifiers.byName(configuration.getType()),
+                configuration.getUrl()
+            );
+    }
+
+    @Async
+    @Override
+    public void onApplicationEvent(MinecraftServerEvent event) {
+        if (configuration.getEvents().containsKey(event.getType())) {
+            var substitutor = new StringSubstitutor(_eventLookup(event));
+            var messageFormat = configuration.getEvents().get(event.getType());
+            var message = substitutor.replace(messageFormat);
+            sender.sendMessage(event, message);
+        }
+    }
+
+    private StringLookup _eventLookup(MinecraftServerEvent event) {
+        return key -> {
+            var property = eventIntrospection.getProperty(key);
+            return property
+                .map(p -> p.get(event))
+                .map(String::valueOf)
+                .orElse(null);
+        };
+    }
+}

--- a/app/src/main/java/org/ethelred/minecraft/webhook/MinecraftServerEventListener.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/MinecraftServerEventListener.java
@@ -1,9 +1,11 @@
+/* (C) Edward Harman 2022 */
 package org.ethelred.minecraft.webhook;
 
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.convert.ConversionService;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.scheduling.annotation.Async;
 import jakarta.inject.Singleton;
@@ -18,13 +20,17 @@ public class MinecraftServerEventListener
     private static final BeanIntrospection<MinecraftServerEvent> eventIntrospection = BeanIntrospection.getIntrospection(
         MinecraftServerEvent.class
     );
+
     private final SenderConfiguration configuration;
     private final Sender sender;
+    private final ConversionService<?> conversionService;
 
     public MinecraftServerEventListener(
         BeanContext beanContext,
+        ConversionService<?> conversionService,
         SenderConfiguration configuration
     ) {
+        this.conversionService = conversionService;
         this.configuration = configuration;
         this.sender =
             beanContext.createBean(
@@ -38,7 +44,12 @@ public class MinecraftServerEventListener
     @Override
     public void onApplicationEvent(MinecraftServerEvent event) {
         if (configuration.getEvents().containsKey(event.getType())) {
-            var substitutor = new StringSubstitutor(_eventLookup(event));
+            var substitutor = new StringSubstitutor(
+                _eventLookup(event),
+                "%",
+                "%",
+                '\\'
+            );
             var messageFormat = configuration.getEvents().get(event.getType());
             var message = substitutor.replace(messageFormat);
             sender.sendMessage(event, message);
@@ -50,7 +61,7 @@ public class MinecraftServerEventListener
             var property = eventIntrospection.getProperty(key);
             return property
                 .map(p -> p.get(event))
-                .map(String::valueOf)
+                .flatMap(o -> conversionService.convert(o, String.class))
                 .orElse(null);
         };
     }

--- a/app/src/main/java/org/ethelred/minecraft/webhook/Monitor.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/Monitor.java
@@ -1,3 +1,4 @@
+/* (C) Edward Harman 2022 */
 package org.ethelred.minecraft.webhook;
 
 import com.github.dockerjava.api.DockerClient;

--- a/app/src/main/java/org/ethelred/minecraft/webhook/Options.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/Options.java
@@ -2,11 +2,11 @@ package org.ethelred.minecraft.webhook;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Context;
-import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
 import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * options for app
@@ -14,6 +14,8 @@ import javax.validation.constraints.NotNull;
 @Context // ensure options are validated early
 @ConfigurationProperties("mc-webhook")
 public class Options {
+
+    private static final Logger LOGGER = LogManager.getLogger();
 
     private static final Set<String> DEFAULT_IMAGE_NAMES = Set.of(
         "itzg/minecraft-bedrock-server"
@@ -33,18 +35,5 @@ public class Options {
         this.imageNames.add(imageName);
     }
 
-    @NotNull(
-        message = "A webhook URL must be provided, for example by specifying the environment variable MC_WEBHOOK_WEBHOOK_URL."
-    )
-    public URL getWebhookUrl() {
-        return webhook;
-    }
-
-    public void setWebhookUrl(URL webhook) {
-        this.webhook = webhook;
-    }
-
     private Set<String> imageNames = new HashSet<>();
-
-    private URL webhook;
 }

--- a/app/src/main/java/org/ethelred/minecraft/webhook/Options.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/Options.java
@@ -1,3 +1,4 @@
+/* (C) Edward Harman 2022 */
 package org.ethelred.minecraft.webhook;
 
 import io.micronaut.context.annotation.ConfigurationProperties;

--- a/app/src/main/java/org/ethelred/minecraft/webhook/Sender.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/Sender.java
@@ -1,3 +1,4 @@
+/* (C) Edward Harman 2022 */
 package org.ethelred.minecraft.webhook;
 
 /**

--- a/app/src/main/java/org/ethelred/minecraft/webhook/Sender.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/Sender.java
@@ -4,5 +4,5 @@ package org.ethelred.minecraft.webhook;
  * I can't believe it's not Consumer
  */
 public interface Sender {
-    void sendMessage(String message);
+    void sendMessage(MinecraftServerEvent event, String message);
 }

--- a/app/src/main/java/org/ethelred/minecraft/webhook/SenderConfiguration.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/SenderConfiguration.java
@@ -1,3 +1,4 @@
+/* (C) Edward Harman 2022 */
 package org.ethelred.minecraft.webhook;
 
 import io.micronaut.context.annotation.EachProperty;
@@ -17,13 +18,13 @@ public class SenderConfiguration {
 
     private Map<MinecraftServerEvent.Type, String> events = Map.of(
         MinecraftServerEvent.Type.SERVER_STARTED,
-        "World ${worldName} starting on ${containerNames}",
+        "World %worldName% starting on %containerName%",
         MinecraftServerEvent.Type.SERVER_STOPPED,
-        "World ${worldName} stopping on ${containerNames}",
+        "World %worldName% stopping on %containerName%",
         MinecraftServerEvent.Type.PLAYER_CONNECTED,
-        "${playerName} connected to ${worldName}",
+        "%playerName% connected to %worldName%",
         MinecraftServerEvent.Type.PLAYER_DISCONNECTED,
-        "${playerName} disconnected from ${worldName}"
+        "%playerName% disconnected from %worldName%"
     );
 
     public String getType() {

--- a/app/src/main/java/org/ethelred/minecraft/webhook/SenderConfiguration.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/SenderConfiguration.java
@@ -1,0 +1,52 @@
+package org.ethelred.minecraft.webhook;
+
+import io.micronaut.context.annotation.EachProperty;
+import java.net.URL;
+import java.util.Map;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@EachProperty("mc-webhook.webhooks")
+public class SenderConfiguration {
+
+    @NotBlank
+    private String type = "discord";
+
+    @NotNull
+    private URL url;
+
+    private Map<MinecraftServerEvent.Type, String> events = Map.of(
+        MinecraftServerEvent.Type.SERVER_STARTED,
+        "World ${worldName} starting on ${containerNames}",
+        MinecraftServerEvent.Type.SERVER_STOPPED,
+        "World ${worldName} stopping on ${containerNames}",
+        MinecraftServerEvent.Type.PLAYER_CONNECTED,
+        "${playerName} connected to ${worldName}",
+        MinecraftServerEvent.Type.PLAYER_DISCONNECTED,
+        "${playerName} disconnected from ${worldName}"
+    );
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public URL getUrl() {
+        return url;
+    }
+
+    public void setUrl(URL url) {
+        this.url = url;
+    }
+
+    public Map<MinecraftServerEvent.Type, String> getEvents() {
+        return events;
+    }
+
+    public void setEvents(Map<MinecraftServerEvent.Type, String> events) {
+        this.events = events;
+    }
+}

--- a/app/src/main/java/org/ethelred/minecraft/webhook/Tailer.java
+++ b/app/src/main/java/org/ethelred/minecraft/webhook/Tailer.java
@@ -1,3 +1,4 @@
+/* (C) Edward Harman 2022 */
 package org.ethelred.minecraft.webhook;
 
 import com.github.dockerjava.api.DockerClient;
@@ -28,7 +29,7 @@ public class Tailer {
     private final Runnable completionCallback;
     private final ApplicationEventPublisher<MinecraftServerEvent> eventPublisher;
     private final String containerId;
-    private final String[] containerNames;
+    private final String containerName;
     private volatile String worldName = "Unknown";
 
     @Inject
@@ -42,8 +43,8 @@ public class Tailer {
         this.eventPublisher = eventPublisher;
         this.completionCallback = completionCallback;
         this.containerId = containerId;
-        this.containerNames = containerNames;
-        LOGGER.info("Tailer is starting for {}", containerNames);
+        this.containerName = String.join(",", containerNames);
+        LOGGER.info("Tailer is starting for {}", containerName);
 
         _initial(docker, containerId);
         _follow(docker, containerId);
@@ -77,7 +78,7 @@ public class Tailer {
                     new MinecraftServerEvent(
                         MinecraftServerEvent.Type.SERVER_STARTED,
                         containerId,
-                        containerNames,
+                        containerName,
                         worldName,
                         null
                     )
@@ -100,7 +101,7 @@ public class Tailer {
                             ? MinecraftServerEvent.Type.PLAYER_CONNECTED
                             : MinecraftServerEvent.Type.PLAYER_DISCONNECTED,
                         containerId,
-                        containerNames,
+                        containerName,
                         worldName,
                         player
                     )
@@ -114,7 +115,7 @@ public class Tailer {
                 new MinecraftServerEvent(
                     MinecraftServerEvent.Type.SERVER_STOPPED,
                     containerId,
-                    containerNames,
+                    containerName,
                     worldName,
                     null
                 )

--- a/app/src/test/groovy/org/ethelred/minecraft/webhook/MonitorSpec.groovy
+++ b/app/src/test/groovy/org/ethelred/minecraft/webhook/MonitorSpec.groovy
@@ -15,6 +15,10 @@ import org.testcontainers.utility.DockerImageName
 import spock.lang.Retry
 import spock.lang.Shared
 import spock.lang.Specification
+
+import java.util.stream.Collectors
+import java.util.stream.Stream
+
 import static org.mockserver.model.HttpRequest.request
 import static org.mockserver.model.HttpResponse.response
 
@@ -46,13 +50,10 @@ class MonitorSpec extends Specification {
         expectation = mockServerClient.when(
                 request().withMethod("POST").withPath("/webhook"))
                 .respond(response().withStatusCode(204))[0]
-        Options options = new Options(
-                imageName: mockBedrock.dockerImageName,
-                webhookUrl: "http://${mockServer.host}:${mockServer.serverPort}/webhook".toURL()
-        )
-
+        
         ApplicationContext applicationContext =ApplicationContext.builder()
-            .singletons(options)
+            .properties("mc-webhook.image-name": mockBedrock.dockerImageName,
+                    "mc-webhook.webhook-url": "http://${mockServer.host}:${mockServer.serverPort}/webhook".toURL())
             .start()
         Monitor monitor = applicationContext.createBean(Monitor)
     }

--- a/app/src/test/resources/config.yml
+++ b/app/src/test/resources/config.yml
@@ -1,7 +1,0 @@
-mc-webhook:
-  imageNames:
-    - poop
-  webhooks:
-    discord1:
-      type: discord
-      url: http://www.example.com

--- a/app/src/test/resources/config.yml
+++ b/app/src/test/resources/config.yml
@@ -1,0 +1,7 @@
+mc-webhook:
+  imageNames:
+    - poop
+  webhooks:
+    discord1:
+      type: discord
+      url: http://www.example.com

--- a/app/src/test/resources/log4j2-test.yml
+++ b/app/src/test/resources/log4j2-test.yml
@@ -1,0 +1,21 @@
+Configuration:
+  status: warn
+  name: config
+
+  appenders:
+    Console:
+      name: STDOUT
+      target: SYSTEM_OUT
+      PatternLayout:
+        Pattern: "%d %p %C{1.} [%t] %m%n"
+
+  Loggers:
+    logger:
+      - name: io.micronaut
+        level: debug
+      - name: org.ethelred
+        level: debug
+    Root:
+      level: info
+      AppenderRef:
+        ref: STDOUT

--- a/buildSrc/src/main/groovy/ethelred.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/ethelred.java-conventions.gradle
@@ -15,6 +15,7 @@ spotless {
         importOrder()
         removeUnusedImports()
         prettier(['prettier': '2.3.2', 'prettier-plugin-java': '1.3.0']).config(['parser': 'java', 'tabWidth': 4])
+        licenseHeader('/* (C) Edward Harman $YEAR */').updateYearWithLatest(true)
     }
     groovyGradle {
         greclipse()


### PR DESCRIPTION
Fixes #3 and #4

- Expand on configuration options.
- Enable multiple webhooks to be configured and operate.
- Messages and events are configurable.
- Can send a JSON data object instead of a message.

TODO:
- document how to configure it
- add player xuid to event